### PR TITLE
Subpath handler for simplerouter

### DIFF
--- a/unstable/simplerouter/router.go
+++ b/unstable/simplerouter/router.go
@@ -137,7 +137,7 @@ func (rg *RouteGroup) Handle(method string, path string, handler http.Handler) {
 }
 
 func (rg *RouteGroup) SubpathHandle(path string, handler http.Handler) {
-	rg.registerRoute("", path, handler.ServeHTTP)
+	rg.Handle("", path, handler)
 }
 
 func (rg *RouteGroup) GET(path string, handler http.Handler) {

--- a/unstable/simplerouter/router.go
+++ b/unstable/simplerouter/router.go
@@ -136,8 +136,8 @@ func (rg *RouteGroup) Handle(method string, path string, handler http.Handler) {
 	rg.HandleFunc(method, path, handler.ServeHTTP)
 }
 
-func (rg *RouteGroup) HandleSubpath(path string, handler http.Handler) {
-	rg.mux.Handle(path, handler)
+func (rg *RouteGroup) SubpathHandle(path string, handler http.Handler) {
+	rg.registerRoute("", path, handler.ServeHTTP)
 }
 
 func (rg *RouteGroup) GET(path string, handler http.Handler) {

--- a/unstable/simplerouter/router.go
+++ b/unstable/simplerouter/router.go
@@ -136,6 +136,10 @@ func (rg *RouteGroup) Handle(method string, path string, handler http.Handler) {
 	rg.HandleFunc(method, path, handler.ServeHTTP)
 }
 
+func (rg *RouteGroup) HandleSubpath(path string, handler http.Handler) {
+	rg.mux.Handle(path, handler)
+}
+
 func (rg *RouteGroup) GET(path string, handler http.Handler) {
 	rg.Handle(http.MethodGet, path, handler)
 }


### PR DESCRIPTION
Default http servemux has a Handle(path string, http.Handler) function which allows handling of entire subpaths. The addition of HandleSubpath does exactly this. It's just a proxy for the RouteGroup's mux's Handle.